### PR TITLE
Add verbose logging of bytes sent to YubiKey and back

### DIFF
--- a/YubiKit/YubiKit/Helpers/Additions/YKFNSDataAdditions+Private.h
+++ b/YubiKit/YubiKit/Helpers/Additions/YKFNSDataAdditions+Private.h
@@ -50,4 +50,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface NSData(NSData_Conversion)
+/*!
+ @method ykf_hexadecimalString:
+ 
+ @return
+    A string from data object which represents each byte as hex symbols.
+ */
+- (NSString *)ykf_hexadecimalString;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/YubiKit/YubiKit/Helpers/Additions/YKFNSDataAdditions.m
+++ b/YubiKit/YubiKit/Helpers/Additions/YKFNSDataAdditions.m
@@ -252,3 +252,27 @@
 }
 
 @end
+
+#pragma mark - HEX string conversion
+
+@implementation NSData (NSData_Conversion)
+
+- (NSString *)ykf_hexadecimalString
+{
+    /* Returns hexadecimal string of NSData. Empty string if data is empty. */
+    const unsigned char *dataBuffer = (const unsigned char *)[self bytes];
+    if (!dataBuffer) {
+        return [NSString string];
+    }
+
+    NSUInteger          dataLength  = [self length];
+    NSMutableString     *hexString  = [NSMutableString stringWithCapacity:(dataLength * 2)];
+    for (int i = 0; i < dataLength; ++i) {
+        [hexString appendFormat:@"%02x", (unsigned int)dataBuffer[i]];
+    }
+
+    return [NSString stringWithString:hexString];
+}
+
+@end
+

--- a/YubiKit/YubiKit/Sessions/AccessorySession/YKFAccessoryConnectionController.m
+++ b/YubiKit/YubiKit/Sessions/AccessorySession/YKFAccessoryConnectionController.m
@@ -241,7 +241,8 @@ static NSUInteger const YubiKeyConnectionControllerReadBufferSize = 512; // byte
     [self dispatchBlockOnCommunicationQueue:^(NSOperation *operation) {
         ykf_safe_strong_self();
         NSDate *commandStartDate = [NSDate date];
-        
+        YKFLogVerbose(@"Sent(IAP): %@", [command.ylpApduData ykf_hexadecimalString]);
+
         // 1. Send the command to the key.
         BOOL success = [strongSelf writeData:command.ylpApduData configuration:configuration parentOperation:operation];
         
@@ -274,7 +275,7 @@ static NSUInteger const YubiKeyConnectionControllerReadBufferSize = 512; // byte
             
             // 3. Read the command result.
             success = [strongSelf readData:&commandResult configuration:configuration parentOperation:operation];
-            
+
             if ((!success || commandResult.length == 0) && !operation.isCancelled) {
                 NSError *error = nil;
                 if (strongSelf.inputStream.streamError) {
@@ -298,10 +299,11 @@ static NSUInteger const YubiKeyConnectionControllerReadBufferSize = 512; // byte
                 YKFLogVerbose(@"The key is busy, processing the request. Waiting for response...");
             }
         }
-        
+
         NSTimeInterval executionTime = [[NSDate date] timeIntervalSinceDate: commandStartDate];
+        YKFLogVerbose(@"Received(IAP): %@", [commandResult ykf_hexadecimalString]);
         commandResult = [self dataAndStatusFromKeyResponse:commandResult];
-        
+
         completion(commandResult, nil, executionTime);
         
         YKFLogVerbose(@"Command execution time: %lf seconds", executionTime);


### PR DESCRIPTION
Sometimes it's useful to see what byte array has been sent and received to/from YubiKey. Adding that information to verbose logging (it's off by default for user)