### PR TITLE
Error handling: tag lost and incorrect credential name

### DIFF
--- a/YubiKit/YubiKit/Sessions/NFCSession/YKFNFCConnectionController.m
+++ b/YubiKit/YubiKit/Sessions/NFCSession/YKFNFCConnectionController.m
@@ -17,6 +17,8 @@
 #import "YKFBlockMacros.h"
 #import "YKFLogger.h"
 #import "YKFAssert.h"
+#import "YKFKeySessionError.h"
+#import "YKFKeySessionError+Private.h"
 #import "YKFNSDataAdditions+Private.h"
 #import "YKFAPDU+Private.h"
 
@@ -67,6 +69,7 @@ typedef void (^YKFKeyConnectionControllerCommunicationQueueBlock)(NSOperation *o
         
         // Check availability before executing. If the command is queued, the tag may become unavailable at execution time.
         if (!strongSelf.tag.isAvailable) {
+            completion(nil, [YKFKeySessionError errorWithCode:YKFKeySessionErrorConnectionLost], 0);
             return;
         }
                 

--- a/YubiKit/YubiKit/Sessions/Shared/Errors/YKFKeyOATHError.h
+++ b/YubiKit/YubiKit/Sessions/Shared/Errors/YKFKeyOATHError.h
@@ -56,7 +56,12 @@ typedef NS_ENUM(NSUInteger, YKFKeyOATHErrorCode) {
     
     /*! Wrong password used for authentication.
      */
-    YKFKeyOATHErrorCodeWrongPassword = 0x000109
+    YKFKeyOATHErrorCodeWrongPassword = 0x000109,
+
+    /*! Object was not found in list of credentials
+     */
+    YKFKeyOATHErrorCodeNoSuchObject = 0x00010A
+
 };
 
 

--- a/YubiKit/YubiKit/Sessions/Shared/Errors/YKFKeyOATHError.m
+++ b/YubiKit/YubiKit/Sessions/Shared/Errors/YKFKeyOATHError.m
@@ -25,6 +25,7 @@ static NSString* const YKFKeyOATHErrorMalformedValidationResponseDescription = @
 static NSString* const YKFKeyOATHErrorBadCalculateAllResponseDescription = @"The key returned a malformed response when calculating all credentials.";
 static NSString* const YKFKeyOATHErrorCodeTouchTimeoutDescription = @"The key did time out, waiting for touch.";
 static NSString* const YKFKeyOATHErrorCodeWrongPasswordDescription = @"Wrong password.";
+static NSString* const YKFKeyOATHErrorCodeNoSuchObjectDescription = @"Credential not found.";
 
 @implementation YKFKeyOATHError
 
@@ -54,7 +55,8 @@ static NSDictionary *errorMap = nil;
       @(YKFKeyOATHErrorCodeBadValidationResponse): YKFKeyOATHErrorMalformedValidationResponseDescription,
       @(YKFKeyOATHErrorCodeBadCalculateAllResponse): YKFKeyOATHErrorBadCalculateAllResponseDescription,
       @(YKFKeyOATHErrorCodeTouchTimeout): YKFKeyOATHErrorCodeTouchTimeoutDescription,
-      @(YKFKeyOATHErrorCodeWrongPassword): YKFKeyOATHErrorCodeWrongPasswordDescription
+      @(YKFKeyOATHErrorCodeWrongPassword): YKFKeyOATHErrorCodeWrongPasswordDescription,
+      @(YKFKeyOATHErrorCodeNoSuchObject): YKFKeyOATHErrorCodeNoSuchObjectDescription
       };
 }
 

--- a/YubiKit/YubiKit/Sessions/Shared/Errors/YKFKeySessionError.h
+++ b/YubiKit/YubiKit/Sessions/Shared/Errors/YKFKeySessionError.h
@@ -54,7 +54,12 @@ typedef NS_ENUM(NSUInteger, YKFKeySessionErrorCode) {
     /*! A certain key application is missing or it was disabled using a configuration tool like YubiKey Manager. In such a scenario
      the functionality of the key should be enabled before trying again the request.
      */
-    YKFKeySessionErrorMissingApplicationCode = 0x000005
+    YKFKeySessionErrorMissingApplicationCode = 0x000005,
+    
+    /*! A request to the key cannot be performed because the connection was lost
+     (e.g. Tag was lost when key was taken away from NFC reader)
+     */
+    YKFKeySessionErrorConnectionLost = 0x000006
 };
 
 /*!

--- a/YubiKit/YubiKit/Sessions/Shared/Errors/YKFKeySessionError.m
+++ b/YubiKit/YubiKit/Sessions/Shared/Errors/YKFKeySessionError.m
@@ -25,6 +25,7 @@ static NSString* const YKFKeySessionErrorWriteTimeoutDescription = @"Unable to w
 static NSString* const YKFKeySessionErrorTouchTimeoutDescription = @"Operation ended. User didn't touch the key.";
 static NSString* const YKFKeySessionErrorKeyBusyDescription = @"The key is busy performing another operation";
 static NSString* const YKFKeySessionErrorMissingApplicationDescription = @"The requested functionality is missing or disabled in the key configuration.";
+static NSString* const YKFKeySessionErrorConnectionLostDescription = @"Connection lost.";
 
 #pragma mark - YKFKeySessionError
 
@@ -53,6 +54,7 @@ static NSDictionary *errorMap = nil;
       @(YKFKeySessionErrorTouchTimeoutCode):        YKFKeySessionErrorTouchTimeoutDescription,
       @(YKFKeySessionErrorKeyBusyCode):             YKFKeySessionErrorKeyBusyDescription,
       @(YKFKeySessionErrorMissingApplicationCode):  YKFKeySessionErrorMissingApplicationDescription,            
+      @(YKFKeySessionErrorConnectionLost):          YKFKeySessionErrorConnectionLostDescription,
       };
 }
 

--- a/YubiKit/YubiKit/Sessions/Shared/Services/OATH/YKFKeyOATHService.m
+++ b/YubiKit/YubiKit/Sessions/Shared/Services/OATH/YKFKeyOATHService.m
@@ -358,6 +358,10 @@ typedef void (^YKFKeyOATHServiceResultCompletionBlock)(NSData* _Nullable  result
                 }
                 break;
                 
+            case YKFKeyAPDUErrorCodeDataInvalid:
+                completion(nil, [YKFKeyOATHError errorWithCode:YKFKeyOATHErrorCodeNoSuchObject]);
+                break;
+
             // Errors - The status code is the error. The key doesn't send any other information.
             default: {
                 YKFKeySessionError *connectionError = [YKFKeySessionError errorWithCode:statusCode];


### PR DESCRIPTION
Return error when tag was lost but execution of operation has been started.
And return specific error code if credential name was incorrect (was removed already or parsed in a wrong way)