### PR TITLE
Expose timeout configurations to raw command execution

### DIFF
--- a/YubiKit/YubiKit/Sessions/Shared/Services/ChalResp/YKFKeyChallengeResponseService.m
+++ b/YubiKit/YubiKit/Sessions/Shared/Services/ChalResp/YKFKeyChallengeResponseService.m
@@ -49,7 +49,7 @@
         completion(nil, [YKFKeyChallengeResponseError errorWithCode:YKFKeyChallengeResponseNoConnection]);
         return;
     }
-    
+       
     [self selectYubiKeyApplication:rawCommandService completion:^(NSError *error) {
         if (error) {
             completion(nil, error);
@@ -67,7 +67,7 @@
     YKFParameterAssertReturn(request);
     YKFParameterAssertReturn(completion);
 
-    [rawCommandService executeCommand:request.apdu completion:^(NSData *response, NSError *error) {
+    [rawCommandService executeCommand:request.apdu configuration:[YKFKeyCommandConfiguration fastCommandCofiguration] completion:^(NSData *response, NSError *error) {
         
         if (error) {
             completion(nil, error);
@@ -96,7 +96,7 @@
                                               completion:(void (^)(NSError *))completion {
     YKFAPDU *selectYubiKeyApplicationAPDU = [[YKFSelectYubiKeyApplicationAPDU alloc] init];
             
-    [rawCommandService executeCommand:selectYubiKeyApplicationAPDU completion:^(NSData *response, NSError *error) {
+    [rawCommandService executeCommand:selectYubiKeyApplicationAPDU configuration:[YKFKeyCommandConfiguration fastCommandCofiguration] completion:^(NSData *response, NSError *error) {
 
         NSError *returnedError = nil;
         

--- a/YubiKit/YubiKit/Sessions/Shared/Services/RawCommand/YKFKeyRawCommandService.h
+++ b/YubiKit/YubiKit/Sessions/Shared/Services/RawCommand/YKFKeyRawCommandService.h
@@ -14,6 +14,7 @@
 
 #import <Foundation/Foundation.h>
 #import "YKFKeyService.h"
+#import "YKFKeyCommandConfiguration.h"
 #import "YKFAPDU.h"
 
 /**
@@ -50,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
     Defines the interface for YKFKeyRawCommandService.
  */
 @protocol YKFKeyRawCommandServiceProtocol<NSObject>
-
+   
 /*!
  @method executeCommand:completion:
  
@@ -90,6 +91,60 @@ NS_ASSUME_NONNULL_BEGIN
     resume its execution.
  */
 - (void)executeSyncCommand:(YKFAPDU *)apdu completion:(YKFKeyRawCommandServiceResponseBlock)completion;
+
+/*!
+@method executeCommand:completion:
+
+@abstract
+    Sends to the key a raw APDU command to be executed by the key. The request is performed asynchronously
+    on a background execution queue.
+
+@param apdu
+    The APDU command to be executed.
+
+@param configuration
+    Allows to specify some configurations for command execution:
+    1) The expected avarage execution time for the command.
+    2) The timeout for a command.
+    3) The time to wait between data availabe checks.
+    Default configuration should work for commands in general, but if you'd like to speed up communication or getting timedout on some heavy operations specify this configurations to fast command or long one.
+
+@param completion
+    The response block which is executed after the request was processed by the key. The completion block
+    will be executed on a background thread.
+
+@note:
+    This method is thread safe and can be invoked from any thread (main or a background thread).
+*/
+- (void)executeCommand:(YKFAPDU *)apdu configuration:(YKFKeyCommandConfiguration *)configuration completion:(YKFKeyRawCommandServiceResponseBlock)completion;
+
+/*!
+ @method executeSyncCommand:completion:
+ 
+ @abstract
+    Sends synchronously to the key a raw APDU command to be executed. Calling this method will block the
+    execution of the calling thread until the request is fulfilled by the key or if it's timing out.
+
+ @discussion
+    This method should never be called from the main thread. If the application calls
+    it from the main thread, an assertion will be fired in debug configurations.
+ 
+ @param apdu
+    The APDU command to be executed.
+ 
+ @param configuration
+    Allows to specify some configurations for command execution:
+    1) The expected avarage execution time for the command.
+    2) The timeout for a command.
+    3) The time to wait between data availabe checks.
+    Default configuration should work for commands in general, but if you'd like to speed up communication or getting timedout on some heavy operations specify this configurations to fast command or long one.
+ 
+ @param completion
+    The response block which is executed after the request was processed by the key. The completion block
+    will be executed on a background thread. After the completion block is executed the calling thread will
+    resume its execution.
+ */
+- (void)executeSyncCommand:(YKFAPDU *)apdu configuration:(YKFKeyCommandConfiguration *)configuration completion:(YKFKeyRawCommandServiceResponseBlock)completion;
 
 @end
 

--- a/YubiKit/YubiKit/Sessions/Shared/YKFKeyCommandConfiguration.h
+++ b/YubiKit/YubiKit/Sessions/Shared/YKFKeyCommandConfiguration.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface YKFKeyCommandConfiguration: NSObject
 
-/// The expected avarage execution time for the command.
+/// The expected avarage execution time for the command. The timeout between sending command to the device and receiving response
 @property (nonatomic, assign) NSTimeInterval commandTime;
 
 /// The timeout for a command.

--- a/YubiKit/YubiKit/Sessions/Shared/YKFKeyCommandConfiguration.m
+++ b/YubiKit/YubiKit/Sessions/Shared/YKFKeyCommandConfiguration.m
@@ -29,7 +29,7 @@
 + (YKFKeyCommandConfiguration *)defaultCommandCofiguration {
     YKFKeyCommandConfiguration *configuration = [[YKFKeyCommandConfiguration alloc] init];
 
-    configuration.commandTime = 0.2;
+    configuration.commandTime = 0.002;
     configuration.commandTimeout = 10;
     configuration.commandProbeTime = 0.05;
     
@@ -39,7 +39,7 @@
 + (YKFKeyCommandConfiguration *)longCommandCofiguration {
     YKFKeyCommandConfiguration *configuration = [[YKFKeyCommandConfiguration alloc] init];
     
-    configuration.commandTime = 2;
+    configuration.commandTime = 0.2;
     configuration.commandTimeout = 30;
     configuration.commandProbeTime = 0.05;
     


### PR DESCRIPTION
User might need to use other than default timeout configuration.
E.g. the speed up execution (if speed is the key value for operation) or wait a bit longer (if operation is slow and reliable response is the key value for operation).
And also lowering the time of command execution, because initial values were too generous.