### PR TITLE
Base32 decoding function updated.

### DIFF
--- a/YubiKit/YubiKit.xcodeproj/project.pbxproj
+++ b/YubiKit/YubiKit.xcodeproj/project.pbxproj
@@ -244,6 +244,7 @@
 		95F75BAB2175D63D00C13DC5 /* YKFKeyOATHValidateRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 95F75BAA2175D63D00C13DC5 /* YKFKeyOATHValidateRequest.m */; };
 		95F75BAE2175D6D600C13DC5 /* YKFOATHValidateAPDU.m in Sources */ = {isa = PBXBuildFile; fileRef = 95F75BAD2175D6D600C13DC5 /* YKFOATHValidateAPDU.m */; };
 		95F75BAF2175D8E300C13DC5 /* YKFKeyOATHValidateRequest.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 95F75BA92175D63D00C13DC5 /* YKFKeyOATHValidateRequest.h */; };
+		A5016E5C24297FEF005A0C21 /* YKFNSDataAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A5016E5B24297FEF005A0C21 /* YKFNSDataAdditionsTests.m */; };
 		A51F7B1D23EFC6DB0046F6A3 /* YKFNSStringAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 95EA81E62178805D0020595D /* YKFNSStringAdditions.m */; };
 		A54DCC0323F2147500E95259 /* YKNSStringAdditionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = A54DCC0223F2147500E95259 /* YKNSStringAdditionTests.m */; };
 /* End PBXBuildFile section */
@@ -706,6 +707,7 @@
 		95F75BAA2175D63D00C13DC5 /* YKFKeyOATHValidateRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = YKFKeyOATHValidateRequest.m; sourceTree = "<group>"; };
 		95F75BAC2175D6D600C13DC5 /* YKFOATHValidateAPDU.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = YKFOATHValidateAPDU.h; sourceTree = "<group>"; };
 		95F75BAD2175D6D600C13DC5 /* YKFOATHValidateAPDU.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = YKFOATHValidateAPDU.m; sourceTree = "<group>"; };
+		A5016E5B24297FEF005A0C21 /* YKFNSDataAdditionsTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = YKFNSDataAdditionsTests.m; sourceTree = "<group>"; };
 		A54DCC0223F2147500E95259 /* YKNSStringAdditionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = YKNSStringAdditionTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1002,6 +1004,7 @@
 				95EF75C1213FEF0500059C79 /* YKFTestCase.h */,
 				95EF75C2213FEF0500059C79 /* YKFTestCase.m */,
 				950C70082298095F00E48458 /* YubiKitDeviceCapabilitiesTests.m */,
+				A5016E5B24297FEF005A0C21 /* YKFNSDataAdditionsTests.m */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1568,6 +1571,7 @@
 				956884CD20AAFB3F00E0F72C /* FakeYubiKitDeviceCapabilities.m in Sources */,
 				9529CBC421492A3E0041D2F8 /* FakeYKFKeyConnectionController.m in Sources */,
 				956884C920AAE70E00E0F72C /* UIDeviceAdditions.m in Sources */,
+				A5016E5C24297FEF005A0C21 /* YKFNSDataAdditionsTests.m in Sources */,
 				95EEEF6321664E4600BE7D7B /* MF_Base32Additions.m in Sources */,
 				95DD659121664B6800BA85C9 /* YKFOATHCredentialTests.m in Sources */,
 				95D61A04216F9159001E7AC8 /* YKFOATHCredentialValidatorTests.m in Sources */,

--- a/YubiKit/YubiKit/Helpers/Additions/YKFNSDataAdditions.h
+++ b/YubiKit/YubiKit/Helpers/Additions/YKFNSDataAdditions.h
@@ -93,7 +93,7 @@ NS_ASSUME_NONNULL_BEGIN
  @method ykf_dataWithBase32String:
  
  @return
-    A data object from a Base32 encoded string or nil if the string could not be parsed.
+    A data object from a Base32 encoded string or nil if the string contains symbol that could not be decoded.
  */
 + (nullable NSData *)ykf_dataWithBase32String:(NSString *)base32String;
 

--- a/YubiKit/YubiKit/Helpers/Additions/YKFNSDataAdditions.m
+++ b/YubiKit/YubiKit/Helpers/Additions/YKFNSDataAdditions.m
@@ -248,7 +248,14 @@
 @implementation NSData(NSData_Base32Additions)
 
 + (NSData *)ykf_dataWithBase32String:(NSString *)base32String {
-    return [self dataWithBase32String:base32String];
+    NSRange range = NSMakeRange(0, [base32String length]);
+    NSError *error = NULL;
+    NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern: @"[A-Za-z2-7=]*" options: 0 error: &error];
+    NSRange foundRange = [regex rangeOfFirstMatchInString: base32String options: 0 range: range];
+    if (NSEqualRanges(range, foundRange))
+        return [self dataWithBase32String: base32String];
+    
+    return nil;
 }
 
 @end

--- a/YubiKit/YubiKit/Helpers/Additions/YKFNSDataAdditions.m
+++ b/YubiKit/YubiKit/Helpers/Additions/YKFNSDataAdditions.m
@@ -252,10 +252,9 @@
     NSError *error = NULL;
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern: @"[A-Za-z2-7=]*" options: 0 error: &error];
     NSRange foundRange = [regex rangeOfFirstMatchInString: base32String options: 0 range: range];
-    if (NSEqualRanges(range, foundRange))
-        return [self dataWithBase32String: base32String];
+    if (NSEqualRanges(range, foundRange)) return nil;
     
-    return nil;
+    return [self dataWithBase32String: base32String];
 }
 
 @end

--- a/YubiKit/YubiKit/Helpers/Additions/YKFNSDataAdditions.m
+++ b/YubiKit/YubiKit/Helpers/Additions/YKFNSDataAdditions.m
@@ -252,7 +252,7 @@
     NSError *error = NULL;
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern: @"[A-Za-z2-7=]*" options: 0 error: &error];
     NSRange foundRange = [regex rangeOfFirstMatchInString: base32String options: 0 range: range];
-    if (NSEqualRanges(range, foundRange)) return nil;
+    if (!NSEqualRanges(range, foundRange)) return nil;
     
     return [self dataWithBase32String: base32String];
 }

--- a/YubiKit/YubiKit/ThirdParties/MF_Base32Additions.m
+++ b/YubiKit/YubiKit/ThirdParties/MF_Base32Additions.m
@@ -62,7 +62,7 @@
                 if( c == '=' ) break; // padding...
 
                 c = decodingTable[c];
-                if( c == __ ) continue;
+                if( c == __ ) return nil;
 
                 encodedBlock[encodedBlockIndex++] = c;
                 if( encodedBlockIndex == 8 ) {

--- a/YubiKit/YubiKit/ThirdParties/MF_Base32Additions.m
+++ b/YubiKit/YubiKit/ThirdParties/MF_Base32Additions.m
@@ -62,7 +62,7 @@
                 if( c == '=' ) break; // padding...
 
                 c = decodingTable[c];
-                if( c == __ ) return nil;
+                if( c == __ ) continue;
 
                 encodedBlock[encodedBlockIndex++] = c;
                 if( encodedBlockIndex == 8 ) {

--- a/YubiKit/YubiKitTests/Tests/YKFNSDataAdditionsTests.m
+++ b/YubiKit/YubiKitTests/Tests/YKFNSDataAdditionsTests.m
@@ -1,0 +1,46 @@
+//
+//  YKFNSDataAdditionsTests.m
+//  YubiKitTests
+//
+//  Created by Irina Rakhmanova on 3/23/20.
+//  Copyright © 2020 Yubico. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "YKFNSDataAdditions.h"
+
+@interface YKFNSDataAdditionsTests : XCTestCase
+@end
+
+@implementation YKFNSDataAdditionsTests
+
+- (void)test_WhenSecretContainsAllSymbolsFromTheTable_ObjectNotNil {
+    NSString *secret = @"Test";
+    NSData *result = [NSData ykf_dataWithBase32String: secret];
+    
+    XCTAssertNotNil(result, @"Returned data object from a Base32 encoded string");
+}
+
+- (void)test_WhenSecretContainsSomeSymbolsNotFromTheTableAndSomeNot_ObjectNil {
+    NSString *secret = @"AAA111";
+    NSData *result = [NSData ykf_dataWithBase32String: secret];
+    
+    XCTAssertNil(result, @"Returned nil because the secret could not be parsed");
+}
+
+- (void)test_WhenSecretContainsNumbersNotFromTheTable_ObjectNil {
+    NSString *secret = @"0189";
+    NSData *result = [NSData ykf_dataWithBase32String: secret];
+    
+    XCTAssertNil(result, @"Returned nil because the secret could not be parsed");
+}
+
+- (void)test_WhenSecretContainsPaddingAndSymbolsFromTheTable_ObjectNotNil {
+    NSString *secret = @"a=2";
+    NSData *result = [NSData ykf_dataWithBase32String: secret];
+    
+    XCTAssertNotNil(result, @"Returned data object from a Base32 encoded string");
+}
+
+@end

--- a/YubiKit/YubiKitTests/Tests/YKFNSDataAdditionsTests.m
+++ b/YubiKit/YubiKitTests/Tests/YKFNSDataAdditionsTests.m
@@ -22,25 +22,25 @@
     XCTAssertNotNil(result, @"Returned data object from a Base32 encoded string");
 }
 
+- (void)test_WhenSecretContainsPaddingAndSymbolsFromTheTable_ObjectNotNil {
+    NSString *secret = @"a2=";
+    NSData *result = [NSData ykf_dataWithBase32String: secret];
+    
+    XCTAssertNotNil(result, @"Returned data object from a Base32 encoded string");
+}
+
 - (void)test_WhenSecretContainsSomeSymbolsNotFromTheTableAndSomeNot_ObjectNil {
     NSString *secret = @"AAA111";
     NSData *result = [NSData ykf_dataWithBase32String: secret];
     
-    XCTAssertNil(result, @"Returned nil because the secret could not be parsed");
+    XCTAssertNil(result, @"Returned nil because the secret contains symbol that could not be decoded");
 }
 
 - (void)test_WhenSecretContainsNumbersNotFromTheTable_ObjectNil {
     NSString *secret = @"0189";
     NSData *result = [NSData ykf_dataWithBase32String: secret];
     
-    XCTAssertNil(result, @"Returned nil because the secret could not be parsed");
-}
-
-- (void)test_WhenSecretContainsPaddingAndSymbolsFromTheTable_ObjectNotNil {
-    NSString *secret = @"a=2";
-    NSData *result = [NSData ykf_dataWithBase32String: secret];
-    
-    XCTAssertNotNil(result, @"Returned data object from a Base32 encoded string");
+    XCTAssertNil(result, @"Returned nil because the secret contains symbol that could not be decoded");
 }
 
 @end


### PR DESCRIPTION
Return nil if a symbol is not from the table instead of skipping the symbol.