### PR TITLE
Fix broken test targets

### DIFF
--- a/YubiKitFullStackTests/YubiKitFullStackTests.xcodeproj/xcshareddata/xcschemes/YubiKitFullStackAutomationTests.xcscheme
+++ b/YubiKitFullStackTests/YubiKitFullStackTests.xcodeproj/xcshareddata/xcschemes/YubiKitFullStackAutomationTests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "95FF5E4520DA4413003CCA16"
+               BuildableName = "YubiKitFullStackAutomationTests.xctest"
+               BlueprintName = "YubiKitFullStackAutomationTests"
+               ReferencedContainer = "container:YubiKitFullStackTests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/YubiKitFullStackTests/YubiKitFullStackTests.xcodeproj/xcshareddata/xcschemes/YubiKitFullStackManualTests.xcscheme
+++ b/YubiKitFullStackTests/YubiKitFullStackTests.xcodeproj/xcshareddata/xcschemes/YubiKitFullStackManualTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1140"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,38 +26,9 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "NO">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "95FF5E4520DA4413003CCA16"
-               BuildableName = "YubiKitFullStackAutomationTests.xctest"
-               BlueprintName = "YubiKitFullStackAutomationTests"
-               ReferencedContainer = "container:YubiKitFullStackTests.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "956884DC20AB289C00E0F72C"
-            BuildableName = "YubiKitFullStackManualTests.app"
-            BlueprintName = "YubiKitFullStackManualTests"
-            ReferencedContainer = "container:YubiKitFullStackTests.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "AUTOMATION_RUNNING"
-            value = "YES"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -79,8 +50,6 @@
             ReferencedContainer = "container:YubiKitFullStackTests.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/YubiKitFullStackTests/YubiKitFullStackTests/ManualTests/ManualTests.m
+++ b/YubiKitFullStackTests/YubiKitFullStackTests/ManualTests/ManualTests.m
@@ -447,7 +447,7 @@ typedef NS_ENUM(NSUInteger, ManualTestsInstruction) {
         [configuration setEnabled:!isOTPenabled application:YKFMGMTApplicationTypeOTP overTransport:transport];
         
         [TestSharedLogger.shared logMessage:@"Updating configuration"];
-        [service writeConfiguration:configuration completion:^(NSError * _Nullable error) {
+        [service writeConfiguration:configuration reboot:NO completion:^(NSError * _Nullable error) {
             if (error) {
                 [TestSharedLogger.shared logError: @"When writing configurations: %@", error.localizedDescription];
                 return;


### PR DESCRIPTION
When checking out a fresh repository the test targets does not build since there are no matching schemes. This alos fixes a minor compilation bug in one of the tests.