### PR TITLE
Make sure xcpretty pass on the result code from CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
                         
       - name: Test on emulator
         run: |
-          xcodebuild -sdk iphonesimulator -workspace YubiKit.xcworkspace -scheme YubiKit -destination "platform=iOS Simulator,OS=13.3,name=iPhone 8" test | xcpretty --test --color
+          set -o pipefail && xcodebuild -sdk iphonesimulator -workspace YubiKit.xcworkspace -scheme YubiKit -destination "platform=iOS Simulator,OS=13.3,name=iPhone 8" test | xcpretty --test --color
          
       - name: Upload artifact
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
Failing tests will fail silently without any indication since xcpretty doesn't pass on the result code from xcodebuild.