### PR TITLE
Clarify docs and sample code for user verification in FIDO2

### DIFF
--- a/YubiKit/YubiKit/Sessions/Shared/Requests/FIDO2/YKFKeyFIDO2MakeCredentialRequest.h
+++ b/YubiKit/YubiKit/Sessions/Shared/Requests/FIDO2/YKFKeyFIDO2MakeCredentialRequest.h
@@ -119,20 +119,20 @@ extern NSString* const YKFKeyFIDO2MakeCredentialRequestOptionUV;
     This parameter is optional.
  
     @code
-    Key           | Default value      | Definition
+    Key           | Definition
+    -------------------------------------------------------------------
+    rk            | resident key: Instructs the authenticator to store
+                    the key material on the device.
     ----------------------------------------------------------------------------------------
-    rk            | false              | resident key: Instructs the authenticator to store
-                                         the key material on the device.
-    ----------------------------------------------------------------------------------------
-    uv            | false              | user verification: Instructs the authenticator to
-                                         require a gesture that verifies the user to complete
-                                         the request. Examples of such gestures are fingerprint
-                                         scan or a PIN.
-    ----------------------------------------------------------------------------------------
-    up            | INVALID            | user presence: The key will return an error if this
-                                         parameter is set when creating a credential.
-                                         UP cannot be configured when creating a credential
-                                         because it's implicitly set to true.
+    uv            | user verification: Instructs the authenticator to
+                    require a gesture that verifies the user to complete
+                    the request. Examples of such gestures are fingerprint
+                    scan or a PIN.
+    -------------------------------------------------------------------
+    up            | user presence: The key will return an error if this
+                    parameter is set when creating a credential.
+                    UP cannot be configured when creating a credential
+                    because it's implicitly set to true.
     @endcode
  */
 @property (nonatomic, nullable) NSDictionary *options;

--- a/YubiKit/YubiKit/Sessions/Shared/Requests/FIDO2/YKFKeyFIDO2MakeCredentialRequest.h
+++ b/YubiKit/YubiKit/Sessions/Shared/Requests/FIDO2/YKFKeyFIDO2MakeCredentialRequest.h
@@ -127,7 +127,8 @@ extern NSString* const YKFKeyFIDO2MakeCredentialRequestOptionUV;
     uv            | user verification: Instructs the authenticator to
                     require a gesture that verifies the user to complete
                     the request. Examples of such gestures are fingerprint
-                    scan or a PIN.
+                    scan or a PIN. This key is not supported by the 5Ci
+                    nor the NFC Yubikeys.
     -------------------------------------------------------------------
     up            | user presence: The key will return an error if this
                     parameter is set when creating a credential.

--- a/docs/fido2.md
+++ b/docs/fido2.md
@@ -89,9 +89,8 @@ A new FIDO2 credential can be created by calling `[executeMakeCredentialRequest:
 #### Swift
 
 ```swift
-// Not a resident key and no PIN required.
-let makeCredentialOptions = [YKFKeyFIDO2MakeCredentialRequestOptionRK: false, 
-								  YKFKeyFIDO2MakeCredentialRequestOptionUV: false]	
+// Not a resident key.
+let makeCredentialOptions = [YKFKeyFIDO2MakeCredentialRequestOptionRK: false]	
 let alg = YKFFIDO2PublicKeyAlgorithmES256
 	
 guard let fido2Service = YubiKitManager.shared.accessorySession.fido2Service else {           
@@ -140,9 +139,8 @@ fido2Service.execute(makeCredentialRequest) { (response, error) in
 #import <YubiKit/YubiKit.h>
 ...
 
-// Not a resident key and no PIN required.
-NSDictionary *makeCredentialOptions = @{YKFKeyFIDO2MakeCredentialRequestOptionRK: @(NO),
-                                        YKFKeyFIDO2MakeCredentialRequestOptionUV: @(NO)};
+// Not a resident key.
+NSDictionary *makeCredentialOptions = @{YKFKeyFIDO2MakeCredentialRequestOptionRK: @(NO)};
 NSInteger alg = YKFFIDO2PublicKeyAlgorithmES256;
 	
 YKFKeyFIDO2MakeCredentialRequest *makeCredentialRequest = [[YKFKeyFIDO2MakeCredentialRequest alloc] init];


### PR DESCRIPTION
Neither Yubikey 5Ci nor NFC supports user verification so setting the user verification key too true or false when creating a FIDO2 credential will cause an error for our current Yubikeys.

Closing #46 