### PR TITLE
update workflow so that Xcode upgrades are less likely to require updating this line

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
                         
       - name: Test on emulator
         run: |
-          set -o pipefail && xcodebuild -sdk iphonesimulator -workspace YubiKit.xcworkspace -scheme YubiKit -destination "platform=iOS Simulator,OS=13.6,name=iPhone 11" test | xcpretty --test --color
+          set -o pipefail && xcodebuild -sdk iphonesimulator -workspace YubiKit.xcworkspace -scheme YubiKit -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" test | xcpretty --test --color
          
       - name: Upload artifact
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
setting it to latest will allow it to work at least until the iPhone 11 is retired