### PR TITLE
Exclude Swift package manager header links from CocoaPods

### DIFF
--- a/YubiKit.podspec
+++ b/YubiKit.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'YubiKit/YubiKit/**/*.{h,m}'
+  s.exclude_files = 'YubiKit/YubiKit/SPMHeaderLinks/*'
 
   s.ios.deployment_target = '11.0'
 end


### PR DESCRIPTION
Having a symlink for every header file causes CocoaPods to generate a project that has duplicated entry for each header file. Installing the current version of YubiKit using CocoaPods will result in a warning starting with:
```
[!] [Xcodeproj] Generated duplicate UUIDs:
PBXFileReference -- Pods.xcodeproj/mainGroup/children/
.....
```
On top of that Xcode will also display a lot of warnings complaining about duplicated entries for Header files.
After some investigation I realized that this is because there's a folder called `SPMHeaderLinks` that contains a symbolic link for every header file. Marking that folder as excluded in `YubiKit.podspec` seems to solve the duplication issue.
