### PR TITLE
Refactored calculation of non-trunkated HMAC signatures using a OATH credential

### DIFF
--- a/YubiKit/YubiKit/Connections/Shared/APDU/OATH/YKFOATHCalculateAPDU.m
+++ b/YubiKit/YubiKit/Connections/Shared/APDU/OATH/YKFOATHCalculateAPDU.m
@@ -48,6 +48,7 @@ static const UInt8 YKFOATHCalculateAPDUChallengeTag = 0x74;
         [data ykf_appendByte:0];
     }
     
+    // P2 is 0x01 for truncated response only
     return [super initWithCla:0 ins:YKFAPDUCommandInstructionOATHCalculate p1:0 p2:1 data:data type:YKFAPDUTypeShort];
 }
 

--- a/YubiKit/YubiKit/Connections/Shared/APDU/OATH/YKFOATHCalculateAPDU.m
+++ b/YubiKit/YubiKit/Connections/Shared/APDU/OATH/YKFOATHCalculateAPDU.m
@@ -48,9 +48,7 @@ static const UInt8 YKFOATHCalculateAPDUChallengeTag = 0x74;
         [data ykf_appendByte:0];
     }
     
-    // P2 is 0x01 for truncated response only
-    UInt8 p2 = credential.notTruncated ? 0x00 : 0x01;
-    return [super initWithCla:0 ins:YKFAPDUCommandInstructionOATHCalculate p1:0 p2:p2 data:data type:YKFAPDUTypeShort];
+    return [super initWithCla:0 ins:YKFAPDUCommandInstructionOATHCalculate p1:0 p2:1 data:data type:YKFAPDUTypeShort];
 }
 
 @end

--- a/YubiKit/YubiKit/Connections/Shared/Sessions/OATH/YKFOATHCode+Private.h
+++ b/YubiKit/YubiKit/Connections/Shared/Sessions/OATH/YKFOATHCode+Private.h
@@ -19,6 +19,6 @@
 
 - (nonnull instancetype)initWithOtp:(nullable NSString *)otp validity:(nonnull NSDateInterval *)validity;
 
-- (nullable instancetype)initWithKeyResponseData:(nonnull NSData *)responseData requestTimetamp:(nonnull NSDate *)timestamp requestPeriod:(NSUInteger)period truncateResult:(BOOL)truncate NS_DESIGNATED_INITIALIZER;
+- (nullable instancetype)initWithKeyResponseData:(nonnull NSData *)responseData requestTimetamp:(nonnull NSDate *)timestamp requestPeriod:(NSUInteger)period NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/YubiKit/YubiKit/Connections/Shared/Sessions/OATH/YKFOATHCode.m
+++ b/YubiKit/YubiKit/Connections/Shared/Sessions/OATH/YKFOATHCode.m
@@ -40,7 +40,7 @@ typedef NS_ENUM(NSUInteger, YKFOATHCalculateResponseType) {
     return self;
 }
 
-- (nullable instancetype)initWithKeyResponseData:(nonnull NSData *)responseData requestTimetamp:(NSDate *)timestamp requestPeriod:(NSUInteger)period truncateResult:(BOOL)truncate {
+- (nullable instancetype)initWithKeyResponseData:(nonnull NSData *)responseData requestTimetamp:(NSDate *)timestamp requestPeriod:(NSUInteger)period {
     YKFAssertAbortInit(responseData.length);
     YKFAssertAbortInit(timestamp);
     
@@ -51,22 +51,15 @@ typedef NS_ENUM(NSUInteger, YKFOATHCalculateResponseType) {
         UInt8 *bytes = (UInt8 *)responseData.bytes;
 
         UInt8 responseType = bytes[0];
-        if (truncate) {
-            YKFAssertAbortInit(responseType == YKFOATHCalculateResponseTypeTruncated);
-        }
+        YKFAssertAbortInit(responseType == YKFOATHCalculateResponseTypeTruncated);
         
         YKFAssertAbortInit([responseData ykf_containsRange:NSMakeRange(1, 2)]);
         UInt8 responseLength = bytes[1];
         UInt8 digits = bytes[2];
         YKFAssertAbortInit(digits == 6 || digits == 7 || digits == 8);
         UInt8 otpBytesLength = responseLength - 1;
-        UInt8 offset;
-        if (truncate) {
-            YKFAssertAbortInit(otpBytesLength == 4);
-            offset = 3;
-        } else {
-            offset = (bytes[responseData.length - 1] & 0xF) + 3;
-        }
+        UInt8 offset = 3;
+        YKFAssertAbortInit(otpBytesLength == 4);
         self.otp = [responseData ykf_parseOATHOTPFromIndex:offset digits:digits];
         YKFAssertAbortInit(self.otp);
         

--- a/YubiKit/YubiKit/Connections/Shared/Sessions/OATH/YKFOATHCredential.h
+++ b/YubiKit/YubiKit/Connections/Shared/Sessions/OATH/YKFOATHCredential.h
@@ -66,11 +66,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) BOOL requiresTouch;
 
-/*!
- The credential requires the user to touch the key to generate it.
- */
-@property (nonatomic) BOOL notTruncated;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/YubiKit/YubiKit/Connections/Shared/Sessions/OATH/YKFOATHSession.h
+++ b/YubiKit/YubiKit/Connections/Shared/Sessions/OATH/YKFOATHSession.h
@@ -99,6 +99,24 @@ typedef void (^YKFOATHSessionCalculateAllCompletionBlock)
 typedef void (^YKFOATHSelectApplicationCompletionBlock)
     (YKFOATHSelectApplicationResponse* _Nullable response, NSError* _Nullable error);
 
+
+/*!
+ @abstract
+    Response block for [executeCalculateResponse:completion:] which provides the result for the execution
+    of the Calculate response request.
+ 
+ @param response
+    The response if the request was successful. In case of error this parameter is nil.
+
+ @param error
+    In case of a failed request this parameter contains the error. If the request was successful this
+    parameter is nil.
+ */
+typedef void (^YKFOATHSessionCalculateResponseCompletionBlock)
+    (NSData* _Nullable response, NSError* _Nullable error);
+
+
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -346,6 +364,31 @@ NS_ASSUME_NONNULL_BEGIN
     This method is thread safe and can be invoked from any thread (main or a background thread).
  */
 - (void)unlockWithPassword:(NSString *)password completion:(YKFOATHSessionGenericCompletionBlock)completion;
+
+
+/*!
+ @method calculateResponse:timestamp:completion:
+ 
+ @abstract
+    Calculate a full (non-truncated) HMAC signature using a Credential.
+    Using this command a Credential can be used as an HMAC key to calculate a result for an arbitrary challenge.
+    The hash algorithm specified for the Credential is used.
+ 
+ @param credentialId
+    The id of the credential to use when calulating the result.
+ 
+ @param challenge
+    The challenge.
+
+ @param completion
+    The response block which is executed after the request was processed by the key. The completion block
+    will be executed on a background thread. If the intention is to update the UI, dispatch the results
+    on the main thread to avoid an UIKit assertion.
+ 
+ @note
+    This method is thread safe and can be invoked from any thread (main or a background thread).
+ */
+- (void)calculateResponseForCredentialID:(NSData *)credentialId challenge:(NSData *)challenge completion:(YKFOATHSessionCalculateResponseCompletionBlock)completion;
 
 /*
  Not available: use only the instance from the YKFAccessorySession.

--- a/YubiKit/YubiKit/Connections/Shared/Sessions/OATH/YKFOATHSession.h
+++ b/YubiKit/YubiKit/Connections/Shared/Sessions/OATH/YKFOATHSession.h
@@ -367,12 +367,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 /*!
- @method calculateResponse:timestamp:completion:
+ @method calculateResponseForCredentialID:challenge:completion:
  
  @abstract
-    Calculate a full (non-truncated) HMAC signature using a Credential.
-    Using this command a Credential can be used as an HMAC key to calculate a result for an arbitrary challenge.
-    The hash algorithm specified for the Credential is used.
+    Calculate a full (non-truncated) HMAC signature using a YKFOATHCredential.
+    Using this command a YKFOATHCredential can be used as an HMAC key to calculate a result for an arbitrary challenge.
+    The hash algorithm specified for the YKFOATHCredential is used.
  
  @param credentialId
     The id of the credential to use when calulating the result.

--- a/YubiKit/YubiKit/Connections/Shared/Sessions/OATH/YKFOATHSession.m
+++ b/YubiKit/YubiKit/Connections/Shared/Sessions/OATH/YKFOATHSession.m
@@ -30,6 +30,8 @@
 
 #import "YKFNSDataAdditions.h"
 #import "YKFNSDataAdditions+Private.h"
+#import "YKFNSMutableDataAdditions.h"
+#import "TKTLVRecordAdditions+Private.h"
 
 #import "YKFAPDU+Private.h"
 
@@ -52,6 +54,11 @@
 
 #import "YKFSmartCardInterface.h"
 #import "YKFSelectApplicationAPDU.h"
+
+static const NSUInteger YKFOATHResponseTag = 0x75;
+static const NSUInteger YKFOATHCredentialIdTag = 0x71;
+static const NSUInteger YKFOATHChallengeTag = 0x74;
+static const NSUInteger YKFOATHCalculateIns = 0xa2;
 
 static const NSTimeInterval YKFOATHServiceTimeoutThreshold = 10; // seconds
 
@@ -192,8 +199,7 @@ typedef void (^YKFOATHServiceResultCompletionBlock)(NSData* _Nullable  result, N
         }
         YKFOATHCode *code = [[YKFOATHCode alloc] initWithKeyResponseData:result
                                                          requestTimetamp:timestamp
-                                                           requestPeriod:credential.period
-                                                          truncateResult:!credential.notTruncated];
+                                                           requestPeriod:credential.period];
         if (!code) {
             completion(nil, [YKFOATHError errorWithCode:YKFOATHErrorCodeBadCalculationResponse]);
             return;
@@ -332,6 +338,36 @@ typedef void (^YKFOATHServiceResultCompletionBlock)(NSData* _Nullable  result, N
         }
         
         completion(nil);
+    }];
+}
+
+- (void)calculateResponseForCredentialID:(NSData *)credentialId challenge:(NSData *)challenge completion:(YKFOATHSessionCalculateResponseCompletionBlock)completion {
+    YKFParameterAssertReturn(credentialId);
+    YKFParameterAssertReturn(challenge);
+    YKFParameterAssertReturn(completion);
+
+    NSMutableData *data = [[NSMutableData alloc] init];
+    [data appendData:[[TKBERTLVRecord alloc] initWithTag:YKFOATHCredentialIdTag value:credentialId].data];
+    [data appendData:[[TKBERTLVRecord alloc] initWithTag:YKFOATHChallengeTag value:challenge].data];
+    
+    YKFAPDU *apdu = [[YKFAPDU alloc] initWithCla:0 ins:YKFOATHCalculateIns p1:0 p2:0 data:data type:YKFAPDUTypeShort];
+    
+    [self executeOATHCommand:apdu completion:^(NSData * _Nullable result, NSError * _Nullable error) {
+        if (error) {
+            completion(nil, error);
+            return;
+        }
+        
+        TKBERTLVRecord *responseRecord = [TKBERTLVRecord recordFromData:result];
+
+        if (responseRecord.tag != YKFOATHResponseTag || responseRecord.value.length == 0) {
+            completion(nil, [YKFOATHError errorWithCode:YKFOATHErrorCodeBadCalculationResponse]);
+            return;
+        }
+        NSRange range = NSMakeRange(1, [responseRecord.value length] - 1);
+        NSData *response = [responseRecord.value subdataWithRange:range];
+        
+        completion(response, nil);
     }];
 }
 

--- a/YubiKit/YubiKit/Helpers/Additions/YKFNSDataAdditions.h
+++ b/YubiKit/YubiKit/Helpers/Additions/YKFNSDataAdditions.h
@@ -97,6 +97,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (nullable NSData *)ykf_dataWithBase32String:(NSString *)base32String;
 
+/*!
+ @method ykf_base32String:
+ 
+ @return
+    A Base32 encoded string from the data.
+ */
+- (NSString *)ykf_base32String;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/YubiKit/YubiKit/Helpers/Additions/YKFNSDataAdditions.m
+++ b/YubiKit/YubiKit/Helpers/Additions/YKFNSDataAdditions.m
@@ -335,6 +335,10 @@
     return [self dataWithBase32String: base32String];
 }
 
+- (NSString *)ykf_base32String {
+    return [self base32String];
+}
+
 @end
 
 #pragma mark - HEX string conversion


### PR DESCRIPTION
- Removed `nonTrunkated` parameter from YKFCredential
- Added `calculateResponseForCredentialID:challenge:completion:` to YKFOATHSession