### PR TITLE
Fix for crash on iOS 15 when scanning OTP over NFC

### DIFF
--- a/YubiKit/YubiKit/Connections/NFCConnection/Sessions/YKFNFCOTPSession.m
+++ b/YubiKit/YubiKit/Connections/NFCConnection/Sessions/YKFNFCOTPSession.m
@@ -74,15 +74,15 @@
 - (void)readerSession:(NFCNDEFReaderSession *)session didInvalidateWithError:(NSError *)error {
     YKFAssertOnMainThread();
     
-    self.nfcSession = nil;
     if ([self shouldIgnoreError: error]) {
         return;
     }
     
     YKFLogNSError(error);
     
-    self.nfcOTPResponseBlock(nil, error);
+    if (self.nfcOTPResponseBlock) self.nfcOTPResponseBlock(nil, error);
     self.nfcOTPResponseBlock = nil;
+    self.nfcSession = nil;
 }
 
 - (void)readerSession:(NFCNDEFReaderSession *)session didDetectNDEFs:(NSArray<NFCNDEFMessage *> *)messages {
@@ -90,13 +90,13 @@
     
     id<YKFOTPTokenProtocol> otpToken = [self.otpTokenParser otpTokenFromNfcMessages:messages];
     if (otpToken) {
-        self.nfcOTPResponseBlock(otpToken, nil);
-        self.nfcOTPResponseBlock = nil;
+        if (self.nfcOTPResponseBlock) self.nfcOTPResponseBlock(otpToken, nil);
     } else {
         YKFNFCError *error = [YKFNFCError noTokenAfterScanError];
-        self.nfcOTPResponseBlock(nil, error);
-        self.nfcOTPResponseBlock = nil;
+        if (self.nfcOTPResponseBlock) self.nfcOTPResponseBlock(nil, error);
     }
+    self.nfcOTPResponseBlock = nil;
+    self.nfcSession = nil;
 }
 
 #pragma mark - Helpers

--- a/YubiKit/YubiKit/Connections/NFCConnection/Sessions/YKFNFCOTPSession.m
+++ b/YubiKit/YubiKit/Connections/NFCConnection/Sessions/YKFNFCOTPSession.m
@@ -80,7 +80,9 @@
     
     YKFLogNSError(error);
     
-    if (self.nfcOTPResponseBlock) self.nfcOTPResponseBlock(nil, error);
+    if (self.nfcOTPResponseBlock) {
+        self.nfcOTPResponseBlock(nil, error);
+    }
     self.nfcOTPResponseBlock = nil;
     self.nfcSession = nil;
 }
@@ -90,10 +92,14 @@
     
     id<YKFOTPTokenProtocol> otpToken = [self.otpTokenParser otpTokenFromNfcMessages:messages];
     if (otpToken) {
-        if (self.nfcOTPResponseBlock) self.nfcOTPResponseBlock(otpToken, nil);
+        if (self.nfcOTPResponseBlock) {
+            self.nfcOTPResponseBlock(otpToken, nil);
+        }
     } else {
         YKFNFCError *error = [YKFNFCError noTokenAfterScanError];
-        if (self.nfcOTPResponseBlock) self.nfcOTPResponseBlock(nil, error);
+        if (self.nfcOTPResponseBlock) {
+            self.nfcOTPResponseBlock(nil, error);
+        }
     }
     self.nfcOTPResponseBlock = nil;
     self.nfcSession = nil;


### PR DESCRIPTION
Fixes crash on iOS 15 where readerSession:didInvalidateWithError: was called twice when reading a Yubico OTP over NFC. This would happen if the user pressed cancel, sent the app to the background and then opened the app again.

The crash can not be reproduces running our automated tests which is why no new tests that validates the fix has been added. There's however a test project available here: https://github.com/jensutbult/OTP-Crash

Closes #78