### PR TITLE
Specify CoreNFC as a weak framework

### DIFF
--- a/YubiKit.podspec
+++ b/YubiKit.podspec
@@ -12,4 +12,5 @@ Pod::Spec.new do |s|
   s.exclude_files = 'YubiKit/YubiKit/SPMHeaderLinks/*'
 
   s.ios.deployment_target = '11.0'
+  s.weak_framework = 'CoreNFC'
 end


### PR DESCRIPTION
While using this library we've got reports from users that our application was not able to launch on iPod Touch devices. We're aware that these devices doesn't support NFC, but we didn't even used any features that'd require it. After some investigation we found that if we specify CoreNFC as a weak framework the application works fine on these devices as well as devices that has NFC and builds on that feature.