### PR TITLE
Specify optional frameworks as weak for all installation methods 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "YubiKit",
     platforms: [
-        .iOS(.v10)
+        .iOS(.v9)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ Click + and add the ``libYubiKit.a``
 
 ---
 
+**Optional Framework Dependencies**
+
+YubiKit weakly links to the CoreNFC and CryptoTokenKit system frameworks since these are not present on some supported device/OS combinations.
+If your target project supports devices without these frameworks present, you must avoid using YubiKit features that depend on them or your app will crash.
+
+---
+
 **Enable Custom Lightning Protocol**
 
 `REQUIRED` if you are supporting the YubiKey 5Ci over the Lightning connector.

--- a/YubiKit.podspec
+++ b/YubiKit.podspec
@@ -12,4 +12,6 @@ Pod::Spec.new do |s|
   s.exclude_files = 'YubiKit/YubiKit/SPMHeaderLinks/*'
 
   s.ios.deployment_target = '11.0'
+
+  s.weak_frameworks = 'CoreNFC', 'CryptoTokenKit'
 end

--- a/YubiKit/YubiKit.xcodeproj/project.pbxproj
+++ b/YubiKit/YubiKit.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		51E1B9932577EF05003C1CA4 /* YKFOATHCredentialWithCode.m in Sources */ = {isa = PBXBuildFile; fileRef = 51E1B9922577EF05003C1CA4 /* YKFOATHCredentialWithCode.m */; };
 		51F8E3C42639856A0010686B /* YKFManagementDeviceInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 51F8E3C32639856A0010686B /* YKFManagementDeviceInfo.m */; };
 		51F8E3C7263989520010686B /* YKFManagementSessionFeatures.m in Sources */ = {isa = PBXBuildFile; fileRef = 51F8E3C6263989520010686B /* YKFManagementSessionFeatures.m */; };
+		5F25E0CA2794AAE8001F22A6 /* CryptoTokenKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F25E0C92794AAE8001F22A6 /* CryptoTokenKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		81311F3A23AAFA4A00765522 /* YKFChallengeResponseSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 81311F3923AAFA4A00765522 /* YKFChallengeResponseSession.m */; };
 		813271EC240F265B0084E105 /* YKFManagementSession.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 814813E923EA381F0003893B /* YKFManagementSession.h */; };
 		814813D123EA37F60003893B /* YKFManagementWriteAPDU.m in Sources */ = {isa = PBXBuildFile; fileRef = 814813CD23EA37F60003893B /* YKFManagementWriteAPDU.m */; };
@@ -158,7 +159,7 @@
 		95BA204521F7483100EED927 /* YKFFIDO2GetAssertionResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 95BA204421F7483100EED927 /* YKFFIDO2GetAssertionResponse.m */; };
 		95BA204821F877BA00EED927 /* YKFFIDO2TouchPoolingAPDU.m in Sources */ = {isa = PBXBuildFile; fileRef = 95BA204721F877BA00EED927 /* YKFFIDO2TouchPoolingAPDU.m */; };
 		95C29617206247210091318B /* YubiKit.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 95C29614206247210091318B /* YubiKit.h */; };
-		95C2961F206247450091318B /* CoreNFC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95C2961E206247450091318B /* CoreNFC.framework */; };
+		95C2961F206247450091318B /* CoreNFC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95C2961E206247450091318B /* CoreNFC.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		95C29623206247920091318B /* YKFOTPToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 95C29622206247920091318B /* YKFOTPToken.m */; };
 		95C296262062497C0091318B /* YKFOTPTokenValidator.m in Sources */ = {isa = PBXBuildFile; fileRef = 95C296252062497C0091318B /* YKFOTPTokenValidator.m */; };
 		95C29628206250820091318B /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 95C29627206250820091318B /* AVFoundation.framework */; };
@@ -338,6 +339,7 @@
 		51F8E3C52639893D0010686B /* YKFManagementSessionFeatures.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = YKFManagementSessionFeatures.h; sourceTree = "<group>"; };
 		51F8E3C6263989520010686B /* YKFManagementSessionFeatures.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = YKFManagementSessionFeatures.m; sourceTree = "<group>"; };
 		51F8E3C8263A95AB0010686B /* YKFManagementDeviceInfo+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "YKFManagementDeviceInfo+Private.h"; sourceTree = "<group>"; };
+		5F25E0C92794AAE8001F22A6 /* CryptoTokenKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CryptoTokenKit.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.0.sdk/System/Library/Frameworks/CryptoTokenKit.framework; sourceTree = DEVELOPER_DIR; };
 		811F91EF2383C57B002158ED /* Changelog.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = Changelog.md; path = ../Changelog.md; sourceTree = "<group>"; };
 		81311F3823AAFA4A00765522 /* YKFChallengeResponseSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = YKFChallengeResponseSession.h; sourceTree = "<group>"; };
 		81311F3923AAFA4A00765522 /* YKFChallengeResponseSession.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = YKFChallengeResponseSession.m; sourceTree = "<group>"; };
@@ -635,6 +637,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5F25E0CA2794AAE8001F22A6 /* CryptoTokenKit.framework in Frameworks */,
 				956DB6742063B41E006B1738 /* AudioToolbox.framework in Frameworks */,
 				95C29637206259660091318B /* UIKit.framework in Frameworks */,
 				95C29628206250820091318B /* AVFoundation.framework in Frameworks */,
@@ -1146,6 +1149,7 @@
 		95C2961D206247440091318B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5F25E0C92794AAE8001F22A6 /* CryptoTokenKit.framework */,
 				956DB6732063B41E006B1738 /* AudioToolbox.framework */,
 				95C29636206259660091318B /* UIKit.framework */,
 				95C29627206250820091318B /* AVFoundation.framework */,


### PR DESCRIPTION
## Problem
Attempting to run an app that links to YubiKit on an iOS 12 device fails with

```
dyld: Library not loaded: /System/Library/Frameworks/CryptoTokenKit.framework/CryptoTokenKit
  Referenced from: /private/var/containers/Bundle/Application/17E1DCD2-882E-438C-9138-2F8BA45A786D/Pass.app/Frameworks/YubiKit_3C81011B9560B8C8_PackageProduct.framework/YubiKit_3C81011B9560B8C8_PackageProduct
  Reason: image not found
```

Fixing this issue results in the same error but caused by `CoreNFC` assuming the device does not suppot NFC (e.g. iPhone 6).

## Solution

[Apple's solution to this problem](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/WeakLinking.html) is to "weakly link" to frameworks that may not be present. At dynamic load time symbols from missing frameworks will be bound to `NULL`. The app must then simply avoid using these symbols (could be enforced by app-level `@available` checks).

This has to be configured separately for each of the three supported installation methods.

---

- Fixes #76
- Closes #80