### PR TITLE
Only call didFailConnectingNFC when an error has occurred

### DIFF
--- a/YubiKit/YubiKit/Connections/NFCConnection/YKFNFCConnection.m
+++ b/YubiKit/YubiKit/Connections/NFCConnection/YKFNFCConnection.m
@@ -300,7 +300,7 @@
         case YKFNFCConnectionStateClosed:
             if (previousState == YKFNFCConnectionStateOpen) {
                 [self.delegate didDisconnectNFC:self error:self.nfcConnectionError];
-            } else {
+            } else if (self.nfcConnectionError != nil) {
                  [self.delegate didFailConnectingNFC:self.nfcConnectionError];
             }
             self.connectionController = nil;

--- a/YubiKit/YubiKit/YubiKitManager.m
+++ b/YubiKit/YubiKit/YubiKitManager.m
@@ -120,7 +120,7 @@ static YubiKitManager *sharedInstance;
     [self.delegate didDisconnectNFC:connection error:error];
 }
 
-- (void)didFailConnectingNFC:(NSError *)error {
+- (void)didFailConnectingNFC:(NSError *_Nonnull)error {
     if ([self.delegate respondsToSelector:@selector(didFailConnectingNFC:)]) {
         [self.delegate didFailConnectingNFC:error];
     }


### PR DESCRIPTION
Do not call `didFailConnectingNFC` when connection has been cancelled by calling `stopNFCConnection ` on the NFC connection. This fixes a bug where we would pass on a nil value to a method designated as returning a non nil result.

Closes #94 