### PR TITLE
SmartCardConnection stop crash

### DIFF
--- a/YubiKit/YubiKit/Connections/SmartCardConnection/YKFSmartCardConnection.m
+++ b/YubiKit/YubiKit/Connections/SmartCardConnection/YKFSmartCardConnection.m
@@ -102,6 +102,10 @@ NSString* const YKFSmartCardConnectionErrorDomain = @"com.yubico.smart-card-conn
 }
 
 - (void)stop {
+    if (self.isActive == NO) {
+        return;
+    }
+    
     self.isActive = NO;
     [[TKSmartCardSlotManager defaultManager] removeObserver:self forKeyPath:@"slotNames"];
     [self.connectionController endSession];


### PR DESCRIPTION
Fixes a crash that would occur if `SmartCardConnection.stop()` was called when there was no active connection.