### PR TITLE
Improved error handling in getCertificateInSlot()

### DIFF
--- a/YubiKit/YubiKit/Connections/Shared/Sessions/PIV/YKFPIVSession.m
+++ b/YubiKit/YubiKit/Connections/Shared/Sessions/PIV/YKFPIVSession.m
@@ -433,7 +433,11 @@ int maxPinAttempts = 3;
             NSData *certificateData = [[YKFTLVRecord sequenceOfRecordsFromData:objectData] ykfTLVRecordWithTag:YKFPIVTagCertificate].value;
             CFDataRef cfCertDataRef =  (__bridge CFDataRef)certificateData;
             SecCertificateRef certificate = SecCertificateCreateWithData(nil, cfCertDataRef);
-            completion(certificate, nil);
+            if (certificate != nil) {
+                completion(certificate, nil);
+            } else {
+                completion(nil, [[NSError alloc] initWithDomain:YKFPIVErrorDomain code:YKFPIVFErrorCodeDataParseError userInfo:@{NSLocalizedDescriptionKey: @"Malformed certificate."}]);
+            }
         }
     }];
 }

--- a/YubiKit/YubiKit/Connections/Shared/Sessions/PIV/YKFPIVSession.m
+++ b/YubiKit/YubiKit/Connections/Shared/Sessions/PIV/YKFPIVSession.m
@@ -436,7 +436,7 @@ int maxPinAttempts = 3;
             if (certificate != nil) {
                 completion(certificate, nil);
             } else {
-                completion(nil, [[NSError alloc] initWithDomain:YKFPIVErrorDomain code:YKFPIVFErrorCodeDataParseError userInfo:@{NSLocalizedDescriptionKey: @"Malformed certificate."}]);
+                completion(nil, [[NSError alloc] initWithDomain:YKFPIVErrorDomain code:YKFPIVFErrorCodeDataParseError userInfo:@{NSLocalizedDescriptionKey: @"Failed to parse certificate."}]);
             }
         }
     }];


### PR DESCRIPTION
Fixes issue where getCertificateInSlot() would return both a nil for the certificate and the error at the same time.