### PR TITLE
Fixes #135 - iPhone 15 Pro

### DIFF
--- a/YubiKit/YubiKit/Helpers/Additions/UIDeviceAdditions.h
+++ b/YubiKit/YubiKit/Helpers/Additions/UIDeviceAdditions.h
@@ -46,6 +46,7 @@ typedef NS_ENUM(NSUInteger, YKFDeviceModel) {
     YKFDeviceModelIPhone13,
     YKFDeviceModelIPhoneSE3,
     YKFDeviceModelIPhone14,
+    YKFDeviceModelIPhone15,
 
     
     // iPad models

--- a/YubiKit/YubiKit/Helpers/Additions/UIDeviceAdditions.m
+++ b/YubiKit/YubiKit/Helpers/Additions/UIDeviceAdditions.m
@@ -101,6 +101,9 @@ static YKFDeviceModel ykf_deviceModelInternal = YKFDeviceModelUnknown;
     if ([self ykf_deviceName:deviceName isInList:@[@"iPhone14,7", @"iPhone14,8", @"iPhone15,2", @"iPhone15,3"]]) {
         return YKFDeviceModelIPhone14;
     }
+    if ([self ykf_deviceName:deviceName isInList:@[@"iPhone15,4", @"iPhone15,5", @"iPhone16,1", @"iPhone16,2"]]) {
+        return YKFDeviceModelIPhone15;
+    }
 
     // iPad models
 

--- a/YubiKit/YubiKit/YubiKitDeviceCapabilities.m
+++ b/YubiKit/YubiKit/YubiKitDeviceCapabilities.m
@@ -166,6 +166,7 @@
             deviceModel == YKFDeviceModelIPhone12 ||
             deviceModel == YKFDeviceModelIPhone13 ||
             deviceModel == YKFDeviceModelIPhone14 ||
+            deviceModel == YKFDeviceModelIPhone15 ||
             deviceModel == YKFDeviceModelUnknown; // A newer device which is not in the list yet
     });
     

--- a/YubiKit/YubiKit/YubiKitDeviceCapabilities.m
+++ b/YubiKit/YubiKit/YubiKitDeviceCapabilities.m
@@ -132,7 +132,8 @@
             self.currentUIDevice.ykf_deviceModel == YKFDeviceModelIPadAir4 ||
             self.currentUIDevice.ykf_deviceModel == YKFDeviceModelIPadAir5 ||
             self.currentUIDevice.ykf_deviceModel == YKFDeviceModelIPad10 ||
-            self.currentUIDevice.ykf_deviceModel == YKFDeviceModelIPadPro6) {
+            self.currentUIDevice.ykf_deviceModel == YKFDeviceModelIPadPro6 ||
+            self.currentUIDevice.ykf_deviceModel == YKFDeviceModelIPhone15) {
             return YES;
         }
     }


### PR DESCRIPTION
**Summary:**
> The code for supportsSmartCardOverUSBC (YubiKitDeviceCapabilities.m:127) maintains a table of known devices with USB-C, which has not yet been updated yet.
>
> Device model strings are mapped to yubikit constants in ykf_setupDeviceModel (UIDeviceAdditions.m:22).

This pull request does 3 things.
1. Adds the device names for iPhone 15 and iPhone 15 Pros.
2. Adds support for NFC connectivity to iPhone 15 and iPhone 15 Pro.
3. Adds support for USB-C connectivity to iPhone 15 and iPhone 15 Pro

**Manual Tests:**
Ran this code manually on my iPhone 15 Pro
<img width="959" alt="image" src="https://github.com/Yubico/yubikit-ios/assets/1218847/59e3fd17-f13e-45f5-8468-becc8f7ccfa5">

**Unit Tests:**
This library doesn't have existing tests for these features