### PR TITLE
Fix bug #140 Missing return after completion in PIV signWithKeyInSlot

### DIFF
--- a/YubiKit/YubiKit/Connections/Shared/Sessions/PIV/YKFPIVSession.m
+++ b/YubiKit/YubiKit/Connections/Shared/Sessions/PIV/YKFPIVSession.m
@@ -154,6 +154,7 @@ int maxPinAttempts = 3;
     NSData *payload = [YKFPIVPadding padData:message keyType:keyType algorithm:algorithm error:&padError];
     if (padError != nil) {
         completion(nil, padError);
+        return;
     }
     return [self usePrivateKeyInSlot:slot type:keyType message:payload exponentiation:false completion:^(NSData * _Nullable data, NSError * _Nullable error) {
         completion(data, error);


### PR DESCRIPTION
Three is a missing return after calling completion, just one line of code.

Without the return, the code will continue to run after the 1st `completion()` and then when it calls the 2nd `completion()`, it will throw

`Illegal callback invocation from native module. This callback type only permits a single invocation from native code.`