### PR TITLE
Fix broken credential id parsing

### DIFF
--- a/YubiKit/YubiKit/Connections/Shared/Requests/OATH/YKFOATHCalculateAllResponse.m
+++ b/YubiKit/YubiKit/Connections/Shared/Requests/OATH/YKFOATHCalculateAllResponse.m
@@ -103,7 +103,7 @@ static NSUInteger const YKFOATHCredentialCalculateResultDefaultPeriod = 30; // s
             NSString *account = nil;
             NSString *label = nil;
             
-            [credentialKey ykf_OATHKeyExtractPeriod:&period issuer:&issuer account:&account label:&label];
+            [credentialKey ykf_OATHKeyExtractForType:credential.type period:&period issuer:&issuer account:&account label:&label];
             
             credential.issuer = issuer;
             credential.accountName = account;

--- a/YubiKit/YubiKit/Connections/Shared/Requests/OATH/YKFOATHCalculateAllResponse.m
+++ b/YubiKit/YubiKit/Connections/Shared/Requests/OATH/YKFOATHCalculateAllResponse.m
@@ -103,7 +103,7 @@ static NSUInteger const YKFOATHCredentialCalculateResultDefaultPeriod = 30; // s
             NSString *account = nil;
             NSString *label = nil;
             
-            [credentialKey ykf_OATHKeyExtractForType:credential.type period:&period issuer:&issuer account:&account label:&label];
+            [credentialKey ykf_OATHKeyExtractForType:credential.type period:&period issuer:&issuer account:&account];
             
             credential.issuer = issuer;
             credential.accountName = account;

--- a/YubiKit/YubiKit/Connections/Shared/Requests/OATH/YKFOATHListResponse.m
+++ b/YubiKit/YubiKit/Connections/Shared/Requests/OATH/YKFOATHListResponse.m
@@ -100,7 +100,7 @@ static const int YKFOATHListResponseNameTag = 0x72;
         NSString *account = nil;
         NSString *label = nil;
         
-        [keyString ykf_OATHKeyExtractPeriod:&period issuer:&issuer account:&account label:&label];
+        [keyString ykf_OATHKeyExtractForType:credential.type period:&period issuer:&issuer account:&account label:&label];
         credential.period = period;
         credential.issuer = issuer;
         credential.accountName = account;

--- a/YubiKit/YubiKit/Connections/Shared/Requests/OATH/YKFOATHListResponse.m
+++ b/YubiKit/YubiKit/Connections/Shared/Requests/OATH/YKFOATHListResponse.m
@@ -100,7 +100,7 @@ static const int YKFOATHListResponseNameTag = 0x72;
         NSString *account = nil;
         NSString *label = nil;
         
-        [keyString ykf_OATHKeyExtractForType:credential.type period:&period issuer:&issuer account:&account label:&label];
+        [keyString ykf_OATHKeyExtractForType:credential.type period:&period issuer:&issuer account:&account];
         credential.period = period;
         credential.issuer = issuer;
         credential.accountName = account;

--- a/YubiKit/YubiKit/Connections/Shared/Sessions/OATH/YKFOATHCredentialUtils.h
+++ b/YubiKit/YubiKit/Connections/Shared/Sessions/OATH/YKFOATHCredentialUtils.h
@@ -52,12 +52,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSString *)keyFromAccountName:(NSString *)name issuer:(NSString *_Nullable)issuer period:(NSUInteger)period type:(YKFOATHCredentialType)type;
 
-+ (NSString *)labelFromCredentialIdentifier:(id<YKFOATHCredentialIdentifier>)credentialIdentifier __deprecated;
-+ (NSString *)keyFromCredentialIdentifier:(id<YKFOATHCredentialIdentifier>)credentialIdentifier __deprecated;
-
-+ (nullable YKFSessionError *)validateCredentialTemplate:(YKFOATHCredentialTemplate *)credentialTemplate __deprecated;
-+ (nullable YKFSessionError *)validateCredential:(YKFOATHCredential *)credential __deprecated;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/YubiKit/YubiKit/Helpers/Additions/YKFNSStringAdditions.h
+++ b/YubiKit/YubiKit/Helpers/Additions/YKFNSStringAdditions.h
@@ -13,9 +13,10 @@
 // limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import "YKFOATHCredential.h"
 
 @interface NSString(NSString_OATH)
 
-- (void)ykf_OATHKeyExtractPeriod:(NSUInteger *)period issuer:(NSString **)issuer account:(NSString **)account label:(NSString **)label;
+- (void)ykf_OATHKeyExtractForType:(YKFOATHCredentialType)type period:(NSUInteger *)period issuer:(NSString **)issuer account:(NSString **)account label:(NSString **)label;
 
 @end

--- a/YubiKit/YubiKit/Helpers/Additions/YKFNSStringAdditions.h
+++ b/YubiKit/YubiKit/Helpers/Additions/YKFNSStringAdditions.h
@@ -17,6 +17,6 @@
 
 @interface NSString(NSString_OATH)
 
-- (void)ykf_OATHKeyExtractForType:(YKFOATHCredentialType)type period:(NSUInteger *)period issuer:(NSString **)issuer account:(NSString **)account label:(NSString **)label;
+- (void)ykf_OATHKeyExtractForType:(YKFOATHCredentialType)type period:(NSUInteger *)period issuer:(NSString **)issuer account:(NSString **)account;
 
 @end

--- a/YubiKit/YubiKit/Helpers/Additions/YKFNSStringAdditions.m
+++ b/YubiKit/YubiKit/Helpers/Additions/YKFNSStringAdditions.m
@@ -16,7 +16,7 @@
 
 @implementation NSString(NSString_OATH)
 
-- (void)ykf_OATHKeyExtractForType:(YKFOATHCredentialType)type period:(NSUInteger *)period issuer:(NSString **)issuer account:(NSString **)account label:(NSString **)label {
+- (void)ykf_OATHKeyExtractForType:(YKFOATHCredentialType)type period:(NSUInteger *)period issuer:(NSString **)issuer account:(NSString **)account {
     
     if (type == YKFOATHCredentialTypeTOTP) {
         NSError *error = NULL;
@@ -42,6 +42,7 @@
                 *account = [self substringWithRange:accountRange];
             }
         } else {
+            //Invalid id, use it directly as name.
             *account = self;
         }
     } else {

--- a/YubiKit/YubiKit/Helpers/Additions/YKFNSStringAdditions.m
+++ b/YubiKit/YubiKit/Helpers/Additions/YKFNSStringAdditions.m
@@ -16,37 +16,42 @@
 
 @implementation NSString(NSString_OATH)
 
-- (void)ykf_OATHKeyExtractPeriod:(NSUInteger *)period issuer:(NSString **)issuer account:(NSString **)account label:(NSString **)label {
-    NSString *key = self;
-    NSMutableArray *componentsArray;
-
-    // TOTP key with format [period]/[label]
-    if ([key containsString:@"/"]) {
-        NSArray *stringComponents = [key componentsSeparatedByString:@"/"];
-        if (stringComponents.count > 1) {
-            NSUInteger interval = [stringComponents[0] intValue];
-            if (interval) {
-                *period = interval;
-
-                componentsArray = [NSMutableArray arrayWithArray: stringComponents];
-                [componentsArray removeObjectAtIndex: 0];
-                key = [componentsArray componentsJoinedByString: @"/"];
+- (void)ykf_OATHKeyExtractForType:(YKFOATHCredentialType)type period:(NSUInteger *)period issuer:(NSString **)issuer account:(NSString **)account label:(NSString **)label {
+    
+    if (type == YKFOATHCredentialTypeTOTP) {
+        NSError *error = NULL;
+        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"^((\\d+)/)?(([^:]+):)?(.+)$"
+                                                                               options:NSRegularExpressionCaseInsensitive
+                                                                                 error:&error];
+        if (error != nil) { [NSException raise:@"Malformed regex" format:@"Built in regex for parsing yubikey keys is malformed."]; }
+        
+        NSTextCheckingResult *match = [regex matchesInString:self
+                                                       options:0
+                                                         range:NSMakeRange(0, [self length])].firstObject;
+        if (match != nil) {
+            NSRange periodRange = [match rangeAtIndex:2];
+            if (periodRange.location != NSNotFound) {
+                *period = [self substringWithRange:periodRange].intValue;
             }
+            NSRange issuerRange = [match rangeAtIndex:4];
+            if (issuerRange.location != NSNotFound) {
+                *issuer = [self substringWithRange:issuerRange];
+            }
+            NSRange accountRange = [match rangeAtIndex:5];
+            if (accountRange.location != NSNotFound) {
+                *account = [self substringWithRange:accountRange];
+            }
+        } else {
+            *account = self;
         }
-    }
-    
-    *label = key;
-    
-    // Parse the label as [issuer]:[account]
-    if ([key containsString: @":"]) {
-        NSArray *labelComponents = [key componentsSeparatedByString:@":"];
-        *issuer = labelComponents.firstObject;
-
-        componentsArray = [NSMutableArray arrayWithArray: labelComponents];
-        [componentsArray removeObjectAtIndex:0];
-        *account = [componentsArray componentsJoinedByString: @":"];
     } else {
-        *account = key;
+        if ([self containsString: @":"]) {
+            NSArray<NSString*> *parts = [self componentsSeparatedByString:@":"];
+            *issuer = parts[0];
+            *account = parts[1];
+        } else {
+            *account = self;
+        }
     }
 }
 

--- a/YubiKit/YubiKitTests/Tests/YKNSStringAdditionTests.m
+++ b/YubiKit/YubiKitTests/Tests/YKNSStringAdditionTests.m
@@ -21,11 +21,9 @@
     NSUInteger period = 0;
     NSString *issuer = nil;
     NSString *account = nil;
-    NSString *label = nil;
 
-    [credentialKey ykf_OATHKeyExtractPeriod: &period issuer: &issuer account: &account label: &label];
+    [credentialKey ykf_OATHKeyExtractForType:YKFOATHCredentialTypeTOTP period:&period issuer:&issuer account:&account];
     XCTAssertEqual(period, 60, @"");
-    XCTAssertTrue([label isEqualToString:@"Yubico:account@gmail.com"], @"");
 }
 
 - (void)test_WhenKeyContainsSlashAndPeriodNotExists_PeriodIsZero {
@@ -34,11 +32,9 @@
     NSUInteger period = 0;
     NSString *issuer = nil;
     NSString *account = nil;
-    NSString *label = nil;
 
-    [credentialKey ykf_OATHKeyExtractPeriod: &period issuer: &issuer account: &account label: &label];
+    [credentialKey ykf_OATHKeyExtractForType:YKFOATHCredentialTypeTOTP period:&period issuer:&issuer account:&account];
     XCTAssertEqual(period, 0, @"");
-    XCTAssertTrue([label isEqualToString:@"/Yubico:account@gmail.com"], @"");
 }
 
 - (void)test_WhenKeyContainsSlashInTheMiddleOfText_PeriodIsZero {
@@ -47,11 +43,9 @@
     NSUInteger period = 0;
     NSString *issuer = nil;
     NSString *account = nil;
-    NSString *label = nil;
 
-    [credentialKey ykf_OATHKeyExtractPeriod: &period issuer: &issuer account: &account label: &label];
+    [credentialKey ykf_OATHKeyExtractForType:YKFOATHCredentialTypeTOTP period:&period issuer:&issuer account:&account];
     XCTAssertEqual(period, 0, @"");
-    XCTAssertTrue([label isEqualToString:@"Yubico/demo:account@gmail.com"], @"");
 }
 
 - (void)test_WhenKeyContainsSlashAndPeriodExistsAndIssuerNotExists_PeriodIsParsedAndIssuerIsNilAndAccountIsParsed {
@@ -62,10 +56,9 @@
     NSString *account = nil;
     NSString *label = nil;
 
-    [credentialKey ykf_OATHKeyExtractPeriod: &period issuer: &issuer account: &account label: &label];
+    [credentialKey ykf_OATHKeyExtractForType:YKFOATHCredentialTypeTOTP period:&period issuer:&issuer account:&account];
     XCTAssertNil(issuer, @"Issuer parsed as nil");
     XCTAssertNotNil(account, @"Account is parsed");
-    XCTAssertTrue([label isEqualToString:@"account@gmail.com"], @"");
     XCTAssertTrue([account isEqualToString:@"account@gmail.com"], @"");
     XCTAssertEqual(period, 60, @"");
 }
@@ -76,12 +69,10 @@
     NSUInteger period = 0;
     NSString *issuer = nil;
     NSString *account = nil;
-    NSString *label = nil;
 
-    [credentialKey ykf_OATHKeyExtractPeriod: &period issuer: &issuer account: &account label: &label];
+    [credentialKey ykf_OATHKeyExtractForType:YKFOATHCredentialTypeTOTP period:&period issuer:&issuer account:&account];
     XCTAssertNil(issuer, @"Issuer parsed as nil");
     XCTAssertNotNil(account, @"Account is parsed");
-    XCTAssertTrue([label isEqualToString:@"account@gmail.com"], @"");
     XCTAssertTrue([account isEqualToString:@"account@gmail.com"], @"");
     XCTAssertEqual(period, 0, @"");
 }
@@ -92,14 +83,11 @@
     NSUInteger period = 0;
     NSString *issuer = nil;
     NSString *account = nil;
-    NSString *label = nil;
 
-    [credentialKey ykf_OATHKeyExtractPeriod: &period issuer: &issuer account: &account label: &label];
-    XCTAssertNotNil(issuer, @"Issuer is parsed");
+    [credentialKey ykf_OATHKeyExtractForType:YKFOATHCredentialTypeTOTP period:&period issuer:&issuer account:&account];
+    XCTAssertNil(issuer, @"Issuer is not nil");
     XCTAssertNotNil(account, @"Account is parsed");
-    XCTAssertTrue([label isEqualToString:@":account@gmail.com"], @"");
-    XCTAssertTrue([issuer isEqualToString:@""], @"");
-    XCTAssertTrue([account isEqualToString:@"account@gmail.com"], @"");
+    XCTAssertTrue([account isEqualToString:@":account@gmail.com"], @"");
     XCTAssertEqual(period, 0, @"");
 }
 
@@ -109,12 +97,10 @@
     NSUInteger period = 0;
     NSString *issuer = nil;
     NSString *account = nil;
-    NSString *label = nil;
 
-    [credentialKey ykf_OATHKeyExtractPeriod: &period issuer: &issuer account: &account label: &label];
+    [credentialKey ykf_OATHKeyExtractForType:YKFOATHCredentialTypeTOTP period:&period issuer:&issuer account:&account];
     XCTAssertNotNil(issuer, @"Issuer is parsed");
     XCTAssertNotNil(account, @"Account is parsed");
-    XCTAssertTrue([label isEqualToString:@"Yubico:demo:account@gmail.com"], @"");
     XCTAssertTrue([issuer isEqualToString:@"Yubico"], @"");
     XCTAssertTrue([account isEqualToString:@"demo:account@gmail.com"], @"");
     XCTAssertEqual(period, 0, @"");
@@ -126,12 +112,10 @@
     NSUInteger period = 0;
     NSString *issuer = nil;
     NSString *account = nil;
-    NSString *label = nil;
 
-    [credentialKey ykf_OATHKeyExtractPeriod: &period issuer: &issuer account: &account label: &label];
+    [credentialKey ykf_OATHKeyExtractForType:YKFOATHCredentialTypeTOTP period:&period issuer:&issuer account:&account];
     XCTAssertNotNil(issuer, @"Issuer is parsed");
     XCTAssertNotNil(account, @"Account is parsed");
-    XCTAssertTrue([label isEqualToString:@"Yubico:demo:account@gmail.com"], @"");
     XCTAssertTrue([issuer isEqualToString:@"Yubico"], @"");
     XCTAssertTrue([account isEqualToString:@"demo:account@gmail.com"], @"");
     XCTAssertEqual(period, 15, @"");
@@ -143,12 +127,10 @@
     NSUInteger period = 0;
     NSString *issuer = nil;
     NSString *account = nil;
-    NSString *label = nil;
 
-    [credentialKey ykf_OATHKeyExtractPeriod: &period issuer: &issuer account: &account label: &label];
+    [credentialKey ykf_OATHKeyExtractForType:YKFOATHCredentialTypeTOTP period:&period issuer:&issuer account:&account];
     XCTAssertNotNil(issuer, @"Issuer is parsed");
     XCTAssertNotNil(account, @"Account is parsed");
-    XCTAssertTrue([label isEqualToString:@"YubicoDemo:account/test"], @"");
     XCTAssertTrue([issuer isEqualToString:@"YubicoDemo"], @"");
     XCTAssertTrue([account isEqualToString:@"account/test"], @"");
     XCTAssertEqual(period, 0, @"");
@@ -160,12 +142,10 @@
     NSUInteger period = 0;
     NSString *issuer = nil;
     NSString *account = nil;
-    NSString *label = nil;
 
-    [credentialKey ykf_OATHKeyExtractPeriod: &period issuer: &issuer account: &account label: &label];
+    [credentialKey ykf_OATHKeyExtractForType:YKFOATHCredentialTypeTOTP period:&period issuer:&issuer account:&account];
     XCTAssertNotNil(issuer, @"Issuer is parsed");
     XCTAssertNotNil(account, @"Account is parsed");
-    XCTAssertTrue([label isEqualToString:@"Yubico/demo:account/test"], @"");
     XCTAssertTrue([issuer isEqualToString:@"Yubico/demo"], @"");
     XCTAssertTrue([account isEqualToString:@"account/test"], @"");
     XCTAssertEqual(period, 0, @"");
@@ -177,12 +157,10 @@
     NSUInteger period = 0;
     NSString *issuer = nil;
     NSString *account = nil;
-    NSString *label = nil;
 
-    [credentialKey ykf_OATHKeyExtractPeriod: &period issuer: &issuer account: &account label: &label];
+    [credentialKey ykf_OATHKeyExtractForType:YKFOATHCredentialTypeTOTP period:&period issuer:&issuer account:&account];
     XCTAssertNotNil(issuer, @"Issuer is parsed");
     XCTAssertNotNil(account, @"Account is parsed");
-    XCTAssertTrue([label isEqualToString:@"YubicoDemo:account/test"], @"");
     XCTAssertTrue([issuer isEqualToString:@"YubicoDemo"], @"");
     XCTAssertTrue([account isEqualToString:@"account/test"], @"");
     XCTAssertEqual(period, 15, @"");
@@ -194,12 +172,10 @@
     NSUInteger period = 0;
     NSString *issuer = nil;
     NSString *account = nil;
-    NSString *label = nil;
 
-    [credentialKey ykf_OATHKeyExtractPeriod: &period issuer: &issuer account: &account label: &label];
+    [credentialKey ykf_OATHKeyExtractForType:YKFOATHCredentialTypeTOTP period:&period issuer:&issuer account:&account];
     XCTAssertNotNil(issuer, @"Issuer is parsed");
     XCTAssertNotNil(account, @"Account is parsed");
-    XCTAssertTrue([label isEqualToString:@"Yubico/demo:account/test"], @"");
     XCTAssertTrue([issuer isEqualToString:@"Yubico/demo"], @"");
     XCTAssertTrue([account isEqualToString:@"account/test"], @"");
     XCTAssertEqual(period, 15, @"");
@@ -211,12 +187,10 @@
     NSUInteger period = 0;
     NSString *issuer = nil;
     NSString *account = nil;
-    NSString *label = nil;
 
-    [credentialKey ykf_OATHKeyExtractPeriod: &period issuer: &issuer account: &account label: &label];
+    [credentialKey ykf_OATHKeyExtractForType:YKFOATHCredentialTypeTOTP period:&period issuer:&issuer account:&account];
     XCTAssertNotNil(issuer, @"Issuer is parsed");
     XCTAssertNotNil(account, @"Account is parsed");
-    XCTAssertTrue([label isEqualToString:@"Yubico Demo:account:test"], @"");
     XCTAssertTrue([issuer isEqualToString:@"Yubico Demo"], @"");
     XCTAssertTrue([account isEqualToString:@"account:test"], @"");
     XCTAssertEqual(period, 0, @"");


### PR DESCRIPTION
- Both parsing and creation of credential id has been ported from android implementation:
   https://github.com/Yubico/yubikit-android/blob/main/oath/src/main/java/com/yubico/yubikit/oath/CredentialIdUtils.java
 
- Methods marked as deprecated on May 10, 2022 removed from sdk.