### PR TITLE
SmartCard connection state was not correct when delegate was being called

### DIFF
--- a/YubiKit/YubiKit/Connections/SmartCardConnection/YKFSmartCardConnection.m
+++ b/YubiKit/YubiKit/Connections/SmartCardConnection/YKFSmartCardConnection.m
@@ -70,8 +70,8 @@ NSString* const YKFSmartCardConnectionErrorDomain = @"com.yubico.smart-card-conn
                 }
             }];
         } else if (self.connectionController != nil) {
-            [self.delegate didDisconnectSmartCard:self error:nil];
             self.connectionController = nil;
+            [self.delegate didDisconnectSmartCard:self error:nil];
             [self.currentSession clearSessionState];
             self.currentSession = nil;
         }


### PR DESCRIPTION
The delegate was being called before the connectionController was set to nil. This caused the connection to report wrong state if the delegate where to check the connection state when being called.