### PR TITLE
Fixes OATH create credential regression bug

### DIFF
--- a/YubiKit/YubiKit/Connections/Shared/Sessions/OATH/YKFOATHCredentialUtils.m
+++ b/YubiKit/YubiKit/Connections/Shared/Sessions/OATH/YKFOATHCredentialUtils.m
@@ -33,7 +33,7 @@ static const int YKFOATHCredentialValidatorMaxNameSize = 64;
     if (type == YKFOATHCredentialTypeTOTP && period != YKFOATHCredentialDefaultPeriod) {
         [accountId appendFormat:@"%ld/", (unsigned long)period];
     }
-    if (issuer != nil) {
+    if (issuer != nil && issuer.length > 0) {
         [accountId appendFormat:@"%@:", issuer];
     }
     [accountId appendString:name];


### PR DESCRIPTION
This fixes a issue where a ':' would be added to the account name if the client using the SDK fails to set the issuer to nil when the input is an empty string.