### PR TITLE
Command execution would return (nil, nil) instead of (nil, timeoutError) on timeout

### DIFF
--- a/YubiKit/YubiKit/Connections/NFCConnection/YKFNFCConnectionController.m
+++ b/YubiKit/YubiKit/Connections/NFCConnection/YKFNFCConnectionController.m
@@ -100,7 +100,9 @@ static NSTimeInterval const YKFNFCConnectionDefaultTimeout = 10.0;
         }];
         
         // Lock the async call to enforce the sequential execution using the library dispatch queue.
-        dispatch_semaphore_wait(executionSemaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC)));
+        if(dispatch_semaphore_wait(executionSemaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC))) != 0) {
+            executionError = [YKFSessionError errorWithCode:YKFSessionErrorReadTimeoutCode];
+        }
         
         // Do not notify if the operation was canceled.
         if (operation.isCancelled) {

--- a/YubiKit/YubiKit/Connections/SmartCardConnection/YKFSmartCardConnectionController.m
+++ b/YubiKit/YubiKit/Connections/SmartCardConnection/YKFSmartCardConnectionController.m
@@ -131,7 +131,9 @@ static NSTimeInterval const YKFSmartCardConnectionDefaultTimeout = 10.0;
         }];
         
         // Lock the async call to enforce the sequential execution using the library dispatch queue.
-        dispatch_semaphore_wait(executionSemaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC)));
+        if(dispatch_semaphore_wait(executionSemaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC))) != 0) {
+            executionError = [YKFSessionError errorWithCode:YKFSessionErrorReadTimeoutCode];
+        }
         
         // Do not notify if the operation was canceled.
         if (operation.isCancelled) {


### PR DESCRIPTION
This solves an issue where the semaphore would timeout before the command returned either a response or an error. The result of this would be the completion returning a nil response **and** a nil error at the same time.